### PR TITLE
Removed CSS package since not actually loading styles

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import css, {insertRule} from 'next/css';
+import {insertRule} from 'next/css';
 import {Container} from 'muicss/react';
 
 // Custom components


### PR DESCRIPTION
Removed the **css** module to maintain consistency with the rest of the project.
**css** is only necessary if there's styles being imported. 

Per [NextJS#css](https://github.com/zeit/next.js#css), example use case where importing CSS module would be necessary:
```
const style = css({
  background: 'red',
  ':hover': {
    background: 'gray'
  },
  '@media (max-width: 600px)': {
    background: 'blue'
  }
})
```